### PR TITLE
Rubocop 1.26 and formatting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,24 +2,20 @@
 Style/ClassCheck:
   EnforcedStyle: kind_of?
 
-# It's better to be more explicit about the type
-Style/BracesAroundHashParameters:
-  Enabled: false
-
 # specs sometimes have useless assignments, which is fine
 Lint/UselessAssignment:
   Exclude:
     - '**/spec/**/*'
 
 # We could potentially enable the 2 below:
-Style/IndentHash:
+Layout/FirstHashElementIndentation:
   Enabled: false
 
-Style/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 # HoundCI doesn't like this rule
-Style/DotPosition:
+Layout/DotPosition:
   Enabled: false
 
 # We allow !! as it's an easy way to convert ot boolean
@@ -27,7 +23,7 @@ Style/DoubleNegation:
   Enabled: false
 
 # Sometimes we allow a rescue block that doesn't contain code
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: false
 
 # Cop supports --auto-correct.
@@ -79,7 +75,7 @@ Metrics/CyclomaticComplexity:
   Max: 17
 
 # Configuration parameters: AllowURI, URISchemes.
-Metrics/LineLength:
+Layout/LineLength:
   Max: 370
 
 # Configuration parameters: CountKeywordArgs.
@@ -119,7 +115,7 @@ Lint/ParenthesesAsGroupedExpression:
 
 # This would reject is_ in front of methods
 # We use `is_supported?` everywhere already
-Style/PredicateName:
+Naming/PredicateName:
   Enabled: false
 
 # We allow the $
@@ -127,7 +123,7 @@ Style/PerlBackrefs:
   Enabled: false
 
 # Disable '+ should be surrounded with a single space' for xcodebuild_spec.rb
-Style/SpaceAroundOperators:
+Layout/SpaceAroundOperators:
   Exclude:
     - '**/spec/actions_specs/xcodebuild_spec.rb'
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,14 @@ Layout/HashAlignment:
 Layout/DotPosition:
   Enabled: false
 
+# Disable CRLF notices
+Layout/EndOfLine:
+  Enabled: false
+
+# Allow no frozen string literal
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 # We allow !! as it's an easy way to convert ot boolean
 Style/DoubleNegation:
   Enabled: false

--- a/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/actions/automated_test_emulator_run_action.rb
@@ -4,375 +4,375 @@ require 'json'
 module Fastlane
   module Actions
 
-      class AutomatedTestEmulatorRunAction < Action
-        def self.run(params)
-          UI.message("The automated_test_emulator_run plugin is working!")
+    class AutomatedTestEmulatorRunAction < Action
+      def self.run(params)
+        UI.message("The automated_test_emulator_run plugin is working!")
 
-          # Parse JSON with AVD launch confing to array of AVD_scheme objects
-          avd_schemes = Provider::AvdSchemeProvider.get_avd_schemes(params)
+        # Parse JSON with AVD launch confing to array of AVD_scheme objects
+        avd_schemes = Provider::AvdSchemeProvider.get_avd_schemes(params)
 
-          # ADB, AVD helper classes
-          adb_controller = Factory::AdbControllerFactory.get_adb_controller(params)
-          avd_controllers = []
+        # ADB, AVD helper classes
+        adb_controller = Factory::AdbControllerFactory.get_adb_controller(params)
+        avd_controllers = []
 
-          # Create AVD_Controller class for each AVD_scheme
-          for i in 0...avd_schemes.length 
-            avd_controller = Factory::AvdControllerFactory.get_avd_controller(params, avd_schemes[i])
-            avd_controllers << avd_controller
+        # Create AVD_Controller class for each AVD_scheme
+        for i in 0...avd_schemes.length
+          avd_controller = Factory::AvdControllerFactory.get_avd_controller(params, avd_schemes[i])
+          avd_controllers << avd_controller
 
-            if params[:verbose] 
-              # Checking for output files
-              if File.exists?(avd_controller.output_file.path) 
-                UI.message([
-                  "Successfully created tmp output file for AVD:", 
-                  avd_schemes[i].avd_name + ".", 
-                  "File: " + avd_controller.output_file.path].join(" ").green)
+          if params[:verbose]
+            # Checking for output files
+            if File.exists?(avd_controller.output_file.path)
+              UI.message([
+                "Successfully created tmp output file for AVD:",
+                avd_schemes[i].avd_name + ".",
+                "File: " + avd_controller.output_file.path].join(" ").green)
+            else
+              UI.message([
+                "Unable to create output file for AVD:",
+                avd_schemes[i].avd_name + ".",
+                "Output will be delegated to null and lost. Check your save/read permissions."].join(" ").red)
+            end
+          end
+        end
+
+        # Reseting wait states
+        all_avd_launched = false
+        adb_launch_complete = false
+        param_launch_complete = false
+
+        while(!all_avd_launched)
+          # Preparation
+          UI.message("Configuring environment in order to launch emulators: ".yellow)
+          UI.message("Getting avaliable AVDs".yellow)
+          devices = Action.sh(adb_controller.command_get_avds)
+
+          for i in 0...avd_schemes.length
+            unless devices.match(avd_schemes[i].avd_name).nil?
+              UI.message(["AVD with name '", avd_schemes[i].avd_name, "' currently exists."].join("").yellow)
+              if params[:AVD_recreate_new]
+                # Delete existing AVDs
+                UI.message("AVD_create_new parameter set to true.".yellow)
+                UI.message(["Deleting existing AVD with name:", avd_schemes[i].avd_name].join(" ").yellow)
+                Action.sh(avd_controllers[i].command_delete_avd)
+
+                # Re-create AVD
+                UI.message(["Re-creating new AVD."].join(" ").yellow)
+                Action.sh(avd_controllers[i].command_create_avd)
               else
-                UI.message([
-                  "Unable to create output file for AVD:", 
-                  avd_schemes[i].avd_name + ".", 
-                  "Output will be delegated to null and lost. Check your save/read permissions."].join(" ").red)
+                # Use existing AVD
+                UI.message("AVD_recreate_new parameter set to false.".yellow)
+                UI.message("Using existing AVD for tests.".yellow)
               end
+            else
+              # Create AVD
+              UI.message(["AVD with name '", avd_schemes[i].avd_name, "' does not exist. Creating new AVD."].join("").yellow)
+              Action.sh(avd_controllers[i].command_create_avd)
             end
           end
 
-          # Reseting wait states
-          all_avd_launched = false
-          adb_launch_complete = false 
-          param_launch_complete = false
+          # Restart ADB
+          if params[:ADB_restart]
+            UI.message("Restarting adb".yellow)
+            Action.sh(adb_controller.command_stop)
+            Action.sh(adb_controller.command_start)
+          else
+            UI.message("ADB won't be restarted. 'ADB_restart' set to false.".yellow)
+          end
 
-          while(!all_avd_launched)
-            # Preparation
-            UI.message("Configuring environment in order to launch emulators: ".yellow)
-            UI.message("Getting avaliable AVDs".yellow)
-            devices = Action.sh(adb_controller.command_get_avds)
-           
-            for i in 0...avd_schemes.length           
-              unless devices.match(avd_schemes[i].avd_name).nil?
-                UI.message(["AVD with name '", avd_schemes[i].avd_name, "' currently exists."].join("").yellow)
-                if params[:AVD_recreate_new]
-                  # Delete existing AVDs
-                  UI.message("AVD_create_new parameter set to true.".yellow)
-                  UI.message(["Deleting existing AVD with name:", avd_schemes[i].avd_name].join(" ").yellow)
-                  Action.sh(avd_controllers[i].command_delete_avd)
-                 
-                  # Re-create AVD
-                  UI.message(["Re-creating new AVD."].join(" ").yellow)
-                  Action.sh(avd_controllers[i].command_create_avd)
-                else 
-                  # Use existing AVD
-                  UI.message("AVD_recreate_new parameter set to false.".yellow)
-                  UI.message("Using existing AVD for tests.".yellow)
-                end
-              else 
-                # Create AVD
-                UI.message(["AVD with name '", avd_schemes[i].avd_name, "' does not exist. Creating new AVD."].join("").yellow)
-                Action.sh(avd_controllers[i].command_create_avd)
-              end
-            end
-
-            # Restart ADB
-            if params[:ADB_restart]
-              UI.message("Restarting adb".yellow)
-              Action.sh(adb_controller.command_stop)
-              Action.sh(adb_controller.command_start)
+          # Applying custom configs (it's not done directly after create because 'cat' operation seems to fail overwrite)
+          for i in 0...avd_schemes.length
+            UI.message(["Attemting to apply custom config to ", avd_schemes[i].avd_name].join("").yellow)
+            if avd_controllers[i].command_apply_config_avd.eql? ""
+              UI.message(["No config file found for AVD '", avd_schemes[i].avd_name, "'. AVD won't have config.ini applied."].join("").yellow)
             else
-              UI.message("ADB won't be restarted. 'ADB_restart' set to false.".yellow)
+              UI.message(["Config file found! Applying custom config to: ", avd_schemes[i].avd_name].join("").yellow)
+              Action.sh(avd_controllers[i].command_apply_config_avd)
             end
+          end
 
-            # Applying custom configs (it's not done directly after create because 'cat' operation seems to fail overwrite)
+          # Launching AVDs
+          UI.message("Launching all AVDs at the same time.".yellow)
+          for i in 0...avd_controllers.length
+            Process.fork do
+              Action.sh(avd_controllers[i].command_start_avd)
+            end
+          end
+
+          # Wait for AVDs finish booting
+          UI.message("Waiting for AVDs to finish booting.".yellow)
+          UI.message("Performing wait for ADB boot".yellow)
+          adb_launch_complete = wait_for_emulator_boot_by_adb(adb_controller, avd_schemes, "#{params[:AVD_adb_launch_timeout]}")
+
+          # Wait for AVD params finish booting
+          if adb_launch_complete
+            UI.message("Wait for ADB boot completed with success".yellow)
+
+            if (params[:AVD_wait_for_bootcomplete] || params[:AVD_wait_for_boot_completed] || params[:AVD_wait_for_bootanim])
+              message = "Performing wait for params: "
+
+              if params[:AVD_wait_for_bootcomplete]
+                message += "'dev.bootcomplete', "
+              end
+
+              if params[:AVD_wait_for_boot_completed]
+                message += "'sys.boot_completed', "
+              end
+
+              if params[:AVD_wait_for_bootanim]
+                message += "'init.svc.bootanim', "
+              end
+
+              message = message[0...-2] + "."
+              UI.message(message.yellow)
+
+              param_launch_complete = wait_for_emulator_boot_by_params(params, adb_controller, avd_controllers, avd_schemes, "#{params[:AVD_param_launch_timeout]}")
+            else
+              UI.message("Wait for AVD launch params was turned off. Skipping...".yellow)
+              param_launch_complete = true
+            end
+          else
+            UI.message("Wait for ADB boot failed".yellow)
+          end
+
+          all_avd_launched = adb_launch_complete && param_launch_complete
+
+          # Deciding if AVD launch should be restarted
+          devices_output = Action.sh(adb_controller.command_get_devices)
+
+          devices = ""
+          devices_output.each_line do |line|
+            if line.include?("emulator-")
+              devices += line.sub(/\t/, " ")
+            end
+          end
+
+          if all_avd_launched
+            UI.message("AVDs Booted!".green)
+            if params[:logcat]
+              for i in 0...avd_schemes.length
+                device = ["emulator-", avd_schemes[i].launch_avd_port].join('')
+                cmd = [adb_controller.adb_path, '-s', device, 'logcat -c'].join(' ')
+                Action.sh(cmd) unless devices.match(device).nil?
+              end
+            end
+          else
             for i in 0...avd_schemes.length
-              UI.message(["Attemting to apply custom config to ", avd_schemes[i].avd_name].join("").yellow)
-              if avd_controllers[i].command_apply_config_avd.eql? "" 
-                 UI.message(["No config file found for AVD '", avd_schemes[i].avd_name, "'. AVD won't have config.ini applied."].join("").yellow)
-              else
-                UI.message(["Config file found! Applying custom config to: ", avd_schemes[i].avd_name].join("").yellow)
-                Action.sh(avd_controllers[i].command_apply_config_avd)
+              if params[:verbose]
+                # Display AVD output
+                if (File.exists?(avd_controllers[i].output_file.path))
+                  UI.message(["Displaying log for AVD:", avd_schemes[i].avd_name].join(" ").red)
+                  UI.message(avd_controllers[i].output_file.read.blue)
+                end
+              end
+
+              # Killing devices
+              unless devices.match(["emulator-", avd_schemes[i].launch_avd_port].join("")).nil?
+                Action.sh(avd_controllers[i].command_kill_device)
+              end
+            end
+          end
+        end
+
+        # Launching tests
+        shell_task = "#{params[:shell_task]}" unless params[:shell_task].nil?
+        gradle_task = "#{params[:gradle_task]}" unless params[:gradle_task].nil?
+
+        UI.message("Starting tests".green)
+        begin
+          unless shell_task.nil?
+            UI.message("Using shell task.".green)
+            Action.sh(shell_task)
+          end
+
+          unless gradle_task.nil?
+            gradle = Helper::GradleHelper.new(gradle_path: Dir["./gradlew"].last)
+
+            UI.message("Using gradle task.".green)
+            gradle.trigger(task: params[:gradle_task], flags: params[:gradle_flags], serial: nil)
+          end
+        ensure
+          # Clean up
+          for i in 0...avd_schemes.length
+            # Kill all emulators
+            device = ["emulator-", avd_schemes[i].launch_avd_port].join("")
+            unless devices.match(device).nil?
+              if params[:logcat]
+                file = [device, '.log'].join('')
+                cmd = [adb_controller.adb_path, '-s', device, 'logcat -d >', file].join(' ')
+                Action.sh(cmd)
+              end
+              Action.sh(avd_controllers[i].command_kill_device)
+            end
+
+            if params[:verbose]
+              # Display AVD output
+              if (File.exists?(avd_controllers[i].output_file.path))
+                UI.message("Displaying log from AVD to console:".green)
+                UI.message(avd_controllers[i].output_file.read.blue)
+
+                UI.message("Removing temp file.".green)
+                avd_controllers[i].output_file.close
+                avd_controllers[i].output_file.unlink
               end
             end
 
-            # Launching AVDs
-            UI.message("Launching all AVDs at the same time.".yellow)
-            for i in 0...avd_controllers.length
-              Process.fork do
-                Action.sh(avd_controllers[i].command_start_avd)
-              end
+            # Delete AVDs
+            if params[:AVD_clean_after]
+              UI.message("AVD_clean_after param set to true. Deleting AVDs.".green)
+              Action.sh(avd_controllers[i].command_delete_avd)
+            else
+              UI.message("AVD_clean_after param set to false. Created AVDs won't be deleted.".green)
             end
+          end
+        end
+      end
 
-            # Wait for AVDs finish booting
-            UI.message("Waiting for AVDs to finish booting.".yellow)
-            UI.message("Performing wait for ADB boot".yellow)
-            adb_launch_complete = wait_for_emulator_boot_by_adb(adb_controller, avd_schemes, "#{params[:AVD_adb_launch_timeout]}")
+      def self.wait_for_emulator_boot_by_adb(adb_controller, avd_schemes, timeout)
+        timeoutInSeconds= timeout.to_i
+        interval = 1000 * 10
+        startTime = Time.now
+        lastCheckTime = Time.now
+        launch_status_hash = Hash.new
+        device_visibility_hash = Hash.new
 
-            # Wait for AVD params finish booting
-            if adb_launch_complete
-              UI.message("Wait for ADB boot completed with success".yellow)
+        for i in 0...avd_schemes.length
+          device_name = ["emulator-", avd_schemes[i].launch_avd_port].join("")
+          launch_status_hash.store(device_name, false)
+          device_visibility_hash.store(device_name, false)
+        end
 
-              if (params[:AVD_wait_for_bootcomplete] || params[:AVD_wait_for_boot_completed] || params[:AVD_wait_for_bootanim])
-                message = "Performing wait for params: "
-                
-                if params[:AVD_wait_for_bootcomplete]
-                  message += "'dev.bootcomplete', "
-                end
-               
-                if params[:AVD_wait_for_boot_completed]
-                  message += "'sys.boot_completed', "
-                end
-               
-                if params[:AVD_wait_for_bootanim]
-                  message += "'init.svc.bootanim', "
-                end
-               
-                message = message[0...-2] + "."
-                UI.message(message.yellow)
-
-                param_launch_complete = wait_for_emulator_boot_by_params(params, adb_controller, avd_controllers, avd_schemes, "#{params[:AVD_param_launch_timeout]}")
-              else
-                UI.message("Wait for AVD launch params was turned off. Skipping...".yellow)
-                param_launch_complete = true
-              end
-            else 
-              UI.message("Wait for ADB boot failed".yellow)
-            end
-
-            all_avd_launched = adb_launch_complete && param_launch_complete
-
-            # Deciding if AVD launch should be restarted
+        launch_status = false
+        loop do
+          currentTime = Time.now
+          if ((currentTime - lastCheckTime) * 1000) > interval
+            lastCheckTime = currentTime
             devices_output = Action.sh(adb_controller.command_get_devices)
 
             devices = ""
             devices_output.each_line do |line|
               if line.include?("emulator-")
-                devices += line.sub(/\t/, " ")  
+                devices += line.sub(/\t/, " ")
               end
             end
-            
-            if all_avd_launched
-              UI.message("AVDs Booted!".green)
-              if params[:logcat]
-                for i in 0...avd_schemes.length
-                  device = ["emulator-", avd_schemes[i].launch_avd_port].join('')
-                  cmd = [adb_controller.adb_path, '-s', device, 'logcat -c'].join(' ')
-                  Action.sh(cmd) unless devices.match(device).nil?
-                end
+
+            # Check if device is visible
+            all_devices_visible = true
+            device_visibility_hash.each do |name, is_visible|
+              unless (devices.match(name).nil? || is_visible)
+                device_visibility_hash[name] = true
               end
-            else
-              for i in 0...avd_schemes.length
-                if params[:verbose] 
-                  # Display AVD output
-                  if (File.exists?(avd_controllers[i].output_file.path))
-                    UI.message(["Displaying log for AVD:", avd_schemes[i].avd_name].join(" ").red)
-                    UI.message(avd_controllers[i].output_file.read.blue)
-                  end
-                end
-                
-                # Killing devices
-                unless devices.match(["emulator-", avd_schemes[i].launch_avd_port].join("")).nil?
-                  Action.sh(avd_controllers[i].command_kill_device)
-                end
+                all_devices_visible = false unless is_visible
+            end
+
+            # Check if device is booted
+            all_devices_booted = true
+            launch_status_hash.each do |name, is_booted|
+              unless (devices.match(name + " device").nil? || is_booted)
+                launch_status_hash[name] = true
               end
+              all_devices_booted = false unless launch_status_hash[name]
+            end
+
+            # Quit if timeout reached
+            if ((currentTime - startTime) >= timeoutInSeconds)
+              UI.message(["AVD ADB loading took more than ", timeout, ". Attempting to re-launch."].join("").red)
+              launch_status = false
+              break
+            end
+
+            # Quit if all devices booted
+            if (all_devices_booted && all_devices_visible)
+              launch_status = true
+              break
             end
           end
+        end
+        return launch_status
+      end
 
-          # Launching tests
-          shell_task = "#{params[:shell_task]}" unless params[:shell_task].nil?
-          gradle_task = "#{params[:gradle_task]}" unless params[:gradle_task].nil?
+      def self.wait_for_emulator_boot_by_params(params, adb_controller, avd_controllers, avd_schemes, timeout)
+        timeout_in_seconds= timeout.to_i
+        interval = 1000 * 10
+        all_params_launched = false
+        start_time = last_scan_ended = Time.now
+        device_boot_statuses = Hash.new
 
-          UI.message("Starting tests".green)
-          begin
-            unless shell_task.nil?
-              UI.message("Using shell task.".green)
-              Action.sh(shell_task)
-            end
+        loop do
+          current_time = Time.now
 
-            unless gradle_task.nil?
-              gradle = Helper::GradleHelper.new(gradle_path: Dir["./gradlew"].last)
-
-              UI.message("Using gradle task.".green)
-              gradle.trigger(task: params[:gradle_task], flags: params[:gradle_flags], serial: nil)
-            end
-          ensure 
-            # Clean up
+          # Performing single scan over each device
+          if (((current_time - last_scan_ended) * 1000) >= interval || start_time == last_scan_ended)
             for i in 0...avd_schemes.length
-              # Kill all emulators
-              device = ["emulator-", avd_schemes[i].launch_avd_port].join("")
-              unless devices.match(device).nil?
-                if params[:logcat]
-                  file = [device, '.log'].join('')
-                  cmd = [adb_controller.adb_path, '-s', device, 'logcat -d >', file].join(' ')
-                  Action.sh(cmd)
-                end
-                Action.sh(avd_controllers[i].command_kill_device)
+              avd_schema = avd_schemes[i]
+              avd_controller = avd_controllers[i]
+              avd_param_boot_hash = Hash.new
+              avd_param_status_hash = Hash.new
+              avd_booted = false
+
+              # Retreiving device parameters according to config
+              if params[:AVD_wait_for_bootcomplete]
+                dev_bootcomplete, _stdeerr, _status = Open3.capture3([avd_controller.command_get_property, "dev.bootcomplete"].join(" "))
+                avd_param_boot_hash.store("dev.bootcomplete", dev_bootcomplete.strip.eql?("1"))
+                avd_param_status_hash.store("dev.bootcomplete", dev_bootcomplete)
               end
 
-              if params[:verbose]
-                # Display AVD output
-                if (File.exists?(avd_controllers[i].output_file.path))
-                  UI.message("Displaying log from AVD to console:".green)
-                  UI.message(avd_controllers[i].output_file.read.blue)
-
-                  UI.message("Removing temp file.".green)
-                  avd_controllers[i].output_file.close
-                  avd_controllers[i].output_file.unlink
-                end
+              if params[:AVD_wait_for_boot_completed]
+                sys_boot_completed, _stdeerr, _status = Open3.capture3([avd_controller.command_get_property, "sys.boot_completed"].join(" "))
+                 avd_param_boot_hash.store("sys.boot_completed", sys_boot_completed.strip.eql?("1"))
+                 avd_param_status_hash.store("sys.boot_completed", sys_boot_completed)
               end
 
-              # Delete AVDs
-              if params[:AVD_clean_after]
-                UI.message("AVD_clean_after param set to true. Deleting AVDs.".green)
-                Action.sh(avd_controllers[i].command_delete_avd)
-              else
-                UI.message("AVD_clean_after param set to false. Created AVDs won't be deleted.".green)
-              end
-            end
-          end
-        end
-
-        def self.wait_for_emulator_boot_by_adb(adb_controller, avd_schemes, timeout)
-          timeoutInSeconds= timeout.to_i
-          interval = 1000 * 10
-          startTime = Time.now
-          lastCheckTime = Time.now
-          launch_status_hash = Hash.new
-          device_visibility_hash = Hash.new
-
-          for i in 0...avd_schemes.length
-            device_name = ["emulator-", avd_schemes[i].launch_avd_port].join("")
-            launch_status_hash.store(device_name, false)
-            device_visibility_hash.store(device_name, false)
-          end
-
-          launch_status = false
-          loop do
-            currentTime = Time.now
-            if ((currentTime - lastCheckTime) * 1000) > interval 
-              lastCheckTime = currentTime
-              devices_output = Action.sh(adb_controller.command_get_devices)
-
-              devices = ""
-              devices_output.each_line do |line|
-                if line.include?("emulator-")
-                  devices += line.sub(/\t/, " ")  
-                end
+              if params[:AVD_wait_for_bootanim]
+                bootanim, _stdeerr, _status = Open3.capture3([avd_controller.command_get_property, "init.svc.bootanim"].join(" "))
+                 avd_param_boot_hash.store("init.svc.bootanim", bootanim.strip.eql?("stopped"))
+                 avd_param_status_hash.store("init.svc.bootanim", bootanim)
               end
 
-              # Check if device is visible
-              all_devices_visible = true
-              device_visibility_hash.each do |name, is_visible|
-                unless (devices.match(name).nil? || is_visible)
-                  device_visibility_hash[name] = true
+              # Checking for param statuses
+              avd_param_boot_hash.each do |name, is_booted|
+                if !is_booted
+                  break
                 end
-                  all_devices_visible = false unless is_visible
+                avd_booted = true
               end
+              device_boot_statuses.store(avd_schema.avd_name, avd_booted)
 
-              # Check if device is booted
-              all_devices_booted = true
-              launch_status_hash.each do |name, is_booted|
-                unless (devices.match(name + " device").nil? || is_booted)
-                  launch_status_hash[name] = true
-                end
-                all_devices_booted = false unless launch_status_hash[name]
-              end
-
-              # Quit if timeout reached
-              if ((currentTime - startTime) >= timeoutInSeconds) 
-                UI.message(["AVD ADB loading took more than ", timeout, ". Attempting to re-launch."].join("").red)
-                launch_status = false
-                break
-              end
-
-              # Quit if all devices booted
-              if (all_devices_booted && all_devices_visible)
-                launch_status = true
-                break
-              end
-            end
-          end
-          return launch_status
-        end
-
-        def self.wait_for_emulator_boot_by_params(params, adb_controller, avd_controllers, avd_schemes, timeout)
-          timeout_in_seconds= timeout.to_i
-          interval = 1000 * 10
-          all_params_launched = false
-          start_time = last_scan_ended = Time.now
-          device_boot_statuses = Hash.new
-
-          loop do
-            current_time = Time.now
-
-            # Performing single scan over each device
-            if (((current_time - last_scan_ended) * 1000) >= interval || start_time == last_scan_ended)
-              for i in 0...avd_schemes.length
-                avd_schema = avd_schemes[i]
-                avd_controller = avd_controllers[i]
-                avd_param_boot_hash = Hash.new
-                avd_param_status_hash = Hash.new
-                avd_booted = false
-                
-                # Retreiving device parameters according to config
-                if params[:AVD_wait_for_bootcomplete]
-                  dev_bootcomplete, _stdeerr, _status = Open3.capture3([avd_controller.command_get_property, "dev.bootcomplete"].join(" "))
-                  avd_param_boot_hash.store("dev.bootcomplete", dev_bootcomplete.strip.eql?("1"))
-                  avd_param_status_hash.store("dev.bootcomplete", dev_bootcomplete)
-                end
-
-                if params[:AVD_wait_for_boot_completed] 
-                   sys_boot_completed, _stdeerr, _status = Open3.capture3([avd_controller.command_get_property, "sys.boot_completed"].join(" "))
-                   avd_param_boot_hash.store("sys.boot_completed", sys_boot_completed.strip.eql?("1"))
-                   avd_param_status_hash.store("sys.boot_completed", sys_boot_completed)
-                end
-
-                if params[:AVD_wait_for_bootanim]
-                   bootanim, _stdeerr, _status = Open3.capture3([avd_controller.command_get_property, "init.svc.bootanim"].join(" ")) 
-                   avd_param_boot_hash.store("init.svc.bootanim", bootanim.strip.eql?("stopped"))
-                   avd_param_status_hash.store("init.svc.bootanim", bootanim)
-                end
-                
-                # Checking for param statuses
-                avd_param_boot_hash.each do |name, is_booted|
-                  if !is_booted
-                    break
-                  end
-                  avd_booted = true
-                end
-                device_boot_statuses.store(avd_schema.avd_name, avd_booted)
-
-                # Plotting current wait results
-                device_log = "Device 'emulator-" + avd_schemes[i].launch_avd_port.to_s + "' launch status:"
+              # Plotting current wait results
+              device_log = "Device 'emulator-" + avd_schemes[i].launch_avd_port.to_s + "' launch status:"
+              UI.message(device_log.magenta)
+              avd_param_boot_hash.each do |name, is_booted|
+                device_log = "'" + name + "' - '" + avd_param_status_hash[name].strip + "' (launched: " + is_booted.to_s + ")"
                 UI.message(device_log.magenta)
-                avd_param_boot_hash.each do |name, is_booted|
-                  device_log = "'" + name + "' - '" + avd_param_status_hash[name].strip + "' (launched: " + is_booted.to_s + ")"
-                  UI.message(device_log.magenta)
-                end
               end
-              last_scan_ended = Time.now
             end
-         
-            # Checking if wait doesn't last too long
-            if (current_time - start_time) >= timeout_in_seconds
-              UI.message(["AVD param loading took more than ", timeout, ". Attempting to re-launch."].join("").red)
-              all_params_launched = false
-              break
-            end
+            last_scan_ended = Time.now
+          end
 
-            # Finishing wait with success if all params are loaded for every device
-            device_boot_statuses.each do |name, is_booted|
-              if !is_booted
-                break
-              end
-              all_params_launched = true
-            end
-            if all_params_launched 
+          # Checking if wait doesn't last too long
+          if (current_time - start_time) >= timeout_in_seconds
+            UI.message(["AVD param loading took more than ", timeout, ". Attempting to re-launch."].join("").red)
+            all_params_launched = false
+            break
+          end
+
+          # Finishing wait with success if all params are loaded for every device
+          device_boot_statuses.each do |name, is_booted|
+            if !is_booted
               break
             end
-          end 
-          return all_params_launched
+            all_params_launched = true
+          end
+          if all_params_launched
+            break
+          end
         end
-       
-        def self.available_options
+        return all_params_launched
+      end
+
+      def self.available_options
         [
-          #paths
+          # paths
           FastlaneCore::ConfigItem.new(key: :AVD_path,
                                        env_name: "AVD_PATH",
                                        description: "The path to your android AVD directory (root). ANDROID_SDK_HOME by default",
@@ -392,7 +392,7 @@ module Fastlane
                                        optional: true),
 
 
-          #launch config params
+          # launch config params
           FastlaneCore::ConfigItem.new(key: :AVD_param_launch_timeout,
                                        env_name: "AVD_PARAM_LAUNCH_TIMEOUT",
                                        description: "Timeout in seconds. Even though ADB might find all devices you still might want to wait for animations to finish and system to boot. Default 60 seconds",
@@ -441,12 +441,12 @@ module Fastlane
                                        default_value: true,
                                        is_string: false,
                                        optional: true),
-          
-          #launch commands
+
+          # launch commands
           FastlaneCore::ConfigItem.new(key: :shell_task,
                                        env_name: "SHELL_TASK",
                                        description: "The shell command you want to execute",
-                                       conflicting_options: [:gradle_task], 
+                                       conflicting_options: [:gradle_task],
                                        is_string: true,
                                        optional: true),
           FastlaneCore::ConfigItem.new(key: :gradle_task,
@@ -462,7 +462,7 @@ module Fastlane
                                        optional: true,
                                        is_string: true),
 
-          #mode
+          # mode
           FastlaneCore::ConfigItem.new(key: :verbose,
                                        env_name: "AVD_VERBOSE",
                                        description: "Allows to turn on/off mode verbose which displays output of AVDs",
@@ -476,19 +476,19 @@ module Fastlane
                                        is_string: false,
                                        optional: true),
         ]
-        end
-
-        def self.description
-            "Starts AVD, based on AVD_setup.json file, before test launch and kills it after testing is done."
-        end
-
-        def self.authors
-            ["F1sherKK"]
-        end
-
-        def self.is_supported?(platform)
-            platform == :android
-        end
       end
+
+      def self.description
+        "Starts AVD, based on AVD_setup.json file, before test launch and kills it after testing is done."
+      end
+
+      def self.authors
+        ["F1sherKK"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+    end
   end
 end

--- a/lib/fastlane/plugin/automated_test_emulator_run/factory/adb_controller_factory.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/factory/adb_controller_factory.rb
@@ -11,52 +11,53 @@ module Fastlane
     end
 
     class AdbControllerFactory
-  
-        def self.get_adb_controller(params)
-          UI.message(["Preparing commands for Android ADB"].join(" ").yellow)
 
-          # Get paths
-          path_sdk = "#{params[:SDK_path]}"
-          path_avdmanager_binary = path_sdk + "/tools/bin/avdmanager"
-          path_adb = path_sdk + "/platform-tools/adb"
+      def self.get_adb_controller(params)
+        UI.message(["Preparing commands for Android ADB"].join(" ").yellow)
 
-          # ADB shell command parts
-          sh_stop_adb = "kill-server"
-          sh_start_adb = "start-server"
-          sh_devices_adb = "devices"
-          sh_wait_for_device_adb = "wait-for-device"
-          sh_list_avd_adb = "list avd"
+        # Get paths
+        path_sdk = "#{params[:SDK_path]}"
+        path_avdmanager_binary = path_sdk + "/tools/bin/avdmanager"
+        path_adb = path_sdk + "/platform-tools/adb"
 
-          # Assemble ADB controller
-          adb_controller = ADB_Controller.new
-          adb_controller.command_stop = [
-           path_adb,
-           sh_stop_adb
-           ].join(" ")
-  
-          adb_controller.command_start = [
-           path_adb,
-           sh_start_adb
-           ].join(" ")
-  
-          adb_controller.command_get_devices = [
-           path_adb,
-           sh_devices_adb
-           ].join(" ")
-  
-          adb_controller.command_wait_for_device = [
-           path_adb,
-           sh_wait_for_device_adb
-           ].join(" ")
+        # ADB shell command parts
+        sh_stop_adb = "kill-server"
+        sh_start_adb = "start-server"
+        sh_devices_adb = "devices"
+        sh_wait_for_device_adb = "wait-for-device"
+        sh_list_avd_adb = "list avd"
 
-          adb_controller.adb_path = path_adb
+        # Assemble ADB controller
+        adb_controller = ADB_Controller.new
+        adb_controller.command_stop = [
+          path_adb,
+          sh_stop_adb
+        ].join(" ")
 
-          adb_controller.command_get_avds = [
-           path_avdmanager_binary, 
-           sh_list_avd_adb].join(" ").chomp
-  
-          return adb_controller
-        end 
+        adb_controller.command_start = [
+          path_adb,
+          sh_start_adb
+        ].join(" ")
+
+        adb_controller.command_get_devices = [
+          path_adb,
+          sh_devices_adb
+        ].join(" ")
+
+        adb_controller.command_wait_for_device = [
+          path_adb,
+          sh_wait_for_device_adb
+        ].join(" ")
+
+        adb_controller.adb_path = path_adb
+
+        adb_controller.command_get_avds = [
+          path_avdmanager_binary,
+          sh_list_avd_adb
+        ].join(" ").chomp
+
+        return adb_controller
+      end
     end
   end
 end

--- a/lib/fastlane/plugin/automated_test_emulator_run/factory/avd_controller_factory.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/factory/avd_controller_factory.rb
@@ -4,126 +4,132 @@ module Fastlane
   module Factory
 
     class AVD_Controller
-        attr_accessor :command_create_avd, :command_start_avd, :command_delete_avd, :command_apply_config_avd, :command_get_property, :command_kill_device,
-                      :output_file
+      attr_accessor :command_create_avd, :command_start_avd, :command_delete_avd, :command_apply_config_avd, :command_get_property, :command_kill_device,
+                    :output_file
 
-        def self.create_output_file(params)
-          output_file = Tempfile.new('emulator_output', '#{params[:AVD_path]}')
-        end
+      def self.create_output_file(params)
+        output_file = Tempfile.new('emulator_output', '#{params[:AVD_path]}')
+      end
     end
 
     class AvdControllerFactory
-  
-        def self.get_avd_controller(params, avd_scheme)
-          UI.message(["Preparing parameters and commands for emulator:", avd_scheme.avd_name].join(" ").yellow)
 
-          # Get paths
-          path_sdk = "#{params[:SDK_path]}"
-          path_avdmanager_binary = path_sdk + "/tools/bin/avdmanager"
-          path_adb = path_sdk + "/platform-tools/adb"
-          path_avd = "#{params[:AVD_path]}"
+      def self.get_avd_controller(params, avd_scheme)
+        UI.message(["Preparing parameters and commands for emulator:", avd_scheme.avd_name].join(" ").yellow)
 
-          # Create AVD shell command parts
-          sh_create_answer_no = "echo \"no\" |"
-          sh_create_avd = "create avd"
-          sh_create_avd_name = ["--name \"", avd_scheme.avd_name, "\""].join("")
-          sh_create_avd_package = ["--package \"", avd_scheme.create_avd_package, "\""].join("")
+        # Get paths
+        path_sdk = "#{params[:SDK_path]}"
+        path_avdmanager_binary = path_sdk + "/tools/bin/avdmanager"
+        path_adb = path_sdk + "/platform-tools/adb"
+        path_avd = "#{params[:AVD_path]}"
 
-          if avd_scheme.create_avd_device.eql? "" 
-            sh_create_avd_device = ""
-          else
-            sh_create_avd_device = ["--device \"", avd_scheme.create_avd_device, "\""].join("")
-          end
+        # Create AVD shell command parts
+        sh_create_answer_no = "echo \"no\" |"
+        sh_create_avd = "create avd"
+        sh_create_avd_name = ["--name \"", avd_scheme.avd_name, "\""].join("")
+        sh_create_avd_package = ["--package \"", avd_scheme.create_avd_package, "\""].join("")
 
-          if avd_scheme.create_avd_abi.eql? "" 
-            sh_create_avd_abi = ""
-          else
-            sh_create_avd_abi = ["--abi ", avd_scheme.create_avd_abi].join("")
-          end
+        if avd_scheme.create_avd_device.eql? ""
+          sh_create_avd_device = ""
+        else
+          sh_create_avd_device = ["--device \"", avd_scheme.create_avd_device, "\""].join("")
+        end
 
-          if avd_scheme.create_avd_tag.eql? "" 
-            sh_create_avd_tag = ""
-          else
-            sh_create_avd_tag = ["--tag ", avd_scheme.create_avd_tag].join("")
-          end
+        if avd_scheme.create_avd_abi.eql? ""
+          sh_create_avd_abi = ""
+        else
+          sh_create_avd_abi = ["--abi ", avd_scheme.create_avd_abi].join("")
+        end
 
-          sh_create_avd_additional_options = avd_scheme.create_avd_additional_options
-          sh_create_config_loc = "#{path_avd}/#{avd_scheme.avd_name}.avd/config.ini"
-          
-          # Launch AVD shell command parts
-          sh_launch_emulator_binary = [path_sdk, "/emulator/", avd_scheme.launch_avd_launch_binary_name].join("")
-          sh_launch_avd_name = ["-avd ", avd_scheme.avd_name].join("")
-          sh_launch_avd_additional_options = avd_scheme.launch_avd_additional_options
-          sh_launch_avd_port = ["-port", avd_scheme.launch_avd_port].join(" ") 
-          
-          if avd_scheme.launch_avd_snapshot_filepath.eql? ""
-             sh_launch_avd_snapshot = ""
-          else
-             sh_launch_avd_snapshot = ["-wipe-data -initdata ", avd_scheme.launch_avd_snapshot_filepath].join("")
-          end   
+        if avd_scheme.create_avd_tag.eql? ""
+          sh_create_avd_tag = ""
+        else
+          sh_create_avd_tag = ["--tag ", avd_scheme.create_avd_tag].join("")
+        end
 
-          # Re-create AVD shell command parts
-          sh_delete_avd = ["delete avd -n ", avd_scheme.avd_name].join("")
+        sh_create_avd_additional_options = avd_scheme.create_avd_additional_options
+        sh_create_config_loc = "#{path_avd}/#{avd_scheme.avd_name}.avd/config.ini"
 
-          # ADB related shell command parts
-          sh_specific_device = "-s"
-          sh_device_name_adb = ["emulator-", avd_scheme.launch_avd_port].join("")
-          sh_get_property = "shell getprop"
-          sh_kill_device = "emu kill"
+        # Launch AVD shell command parts
+        sh_launch_emulator_binary = [path_sdk, "/emulator/", avd_scheme.launch_avd_launch_binary_name].join("")
+        sh_launch_avd_name = ["-avd ", avd_scheme.avd_name].join("")
+        sh_launch_avd_additional_options = avd_scheme.launch_avd_additional_options
+        sh_launch_avd_port = ["-port", avd_scheme.launch_avd_port].join(" ")
 
-          # Assemble AVD controller
-          avd_controller = AVD_Controller.new
-          avd_controller.command_create_avd = [
-            sh_create_answer_no, 
-            path_avdmanager_binary,
-            sh_create_avd,
-            sh_create_avd_name,
-            sh_create_avd_package,
-            sh_create_avd_device,
-            sh_create_avd_tag,
-            sh_create_avd_abi,
-            sh_create_avd_additional_options].join(" ")
+        if avd_scheme.launch_avd_snapshot_filepath.eql? ""
+          sh_launch_avd_snapshot = ""
+        else
+          sh_launch_avd_snapshot = ["-wipe-data -initdata ", avd_scheme.launch_avd_snapshot_filepath].join("")
+        end
 
-          avd_controller.output_file = Tempfile.new('emulator_output')
-          avd_output = File.exists?(avd_controller.output_file) ? ["&>", avd_controller.output_file.path, "&"].join("") : "&>/dev/null &"
-          
-          avd_controller.command_start_avd = [
-           sh_launch_emulator_binary, 
-           sh_launch_avd_port, 
-           sh_launch_avd_name, 
-           sh_launch_avd_snapshot, 
-           sh_launch_avd_additional_options, 
-           avd_output].join(" ")
+        # Re-create AVD shell command parts
+        sh_delete_avd = ["delete avd -n ", avd_scheme.avd_name].join("")
 
-          avd_controller.command_delete_avd = [
-           path_avdmanager_binary,
-           sh_delete_avd].join(" ")
+        # ADB related shell command parts
+        sh_specific_device = "-s"
+        sh_device_name_adb = ["emulator-", avd_scheme.launch_avd_port].join("")
+        sh_get_property = "shell getprop"
+        sh_kill_device = "emu kill"
 
-          if path_avd.nil? || (avd_scheme.create_avd_hardware_config_filepath.eql? "")
-            avd_controller.command_apply_config_avd = ""
-          else
-            avd_controller.command_apply_config_avd = [
-              "cat",
-              avd_scheme.create_avd_hardware_config_filepath,
-              ">",
-              sh_create_config_loc].join(" ")
-          end
-          
-          avd_controller.command_get_property = [
-           path_adb,
-           sh_specific_device,
-           sh_device_name_adb,
-           sh_get_property].join(" ")
+        # Assemble AVD controller
+        avd_controller = AVD_Controller.new
+        avd_controller.command_create_avd = [
+          sh_create_answer_no,
+          path_avdmanager_binary,
+          sh_create_avd,
+          sh_create_avd_name,
+          sh_create_avd_package,
+          sh_create_avd_device,
+          sh_create_avd_tag,
+          sh_create_avd_abi,
+          sh_create_avd_additional_options
+        ].join(" ")
 
-          avd_controller.command_kill_device = [
-           path_adb,
-           sh_specific_device,
-           sh_device_name_adb,
-           sh_kill_device,
-           "&>/dev/null"].join(" ")
+        avd_controller.output_file = Tempfile.new('emulator_output')
+        avd_output = File.exists?(avd_controller.output_file) ? ["&>", avd_controller.output_file.path, "&"].join("") : "&>/dev/null &"
 
-          return avd_controller
-        end 
+        avd_controller.command_start_avd = [
+          sh_launch_emulator_binary,
+          sh_launch_avd_port,
+          sh_launch_avd_name,
+          sh_launch_avd_snapshot,
+          sh_launch_avd_additional_options,
+          avd_output
+        ].join(" ")
+
+        avd_controller.command_delete_avd = [
+          path_avdmanager_binary,
+          sh_delete_avd
+        ].join(" ")
+
+        if path_avd.nil? || (avd_scheme.create_avd_hardware_config_filepath.eql? "")
+          avd_controller.command_apply_config_avd = ""
+        else
+          avd_controller.command_apply_config_avd = [
+            "cat",
+            avd_scheme.create_avd_hardware_config_filepath,
+            ">",
+            sh_create_config_loc
+          ].join(" ")
+        end
+
+        avd_controller.command_get_property = [
+          path_adb,
+          sh_specific_device,
+          sh_device_name_adb,
+          sh_get_property
+        ].join(" ")
+
+        avd_controller.command_kill_device = [
+          path_adb,
+          sh_specific_device,
+          sh_device_name_adb,
+          sh_kill_device,
+          "&>/dev/null"
+        ].join(" ")
+
+        return avd_controller
+      end
     end
   end
 end

--- a/lib/fastlane/plugin/automated_test_emulator_run/provider/avd_setup_provider.rb
+++ b/lib/fastlane/plugin/automated_test_emulator_run/provider/avd_setup_provider.rb
@@ -2,171 +2,171 @@ module Fastlane
   module Provider
 
     class AVD_scheme
-      attr_accessor :avd_name, :create_avd_package, :create_avd_device, :create_avd_tag, :create_avd_abi, :create_avd_hardware_config_filepath, :create_avd_additional_options, 
+      attr_accessor :avd_name, :create_avd_package, :create_avd_device, :create_avd_tag, :create_avd_abi, :create_avd_hardware_config_filepath, :create_avd_additional_options,
                     :launch_avd_port, :launch_avd_launch_binary_name, :launch_avd_additional_options, :launch_avd_snapshot_filepath
     end
 
     class AvdSchemeProvider
-      
-        def self.get_avd_schemes(params)
-        
-          # Read JSON into string variable
-          avd_setup_json = read_avd_setup(params)
-          if avd_setup_json.nil? 
-            throw_error("Unable to read AVD_setup.json. Check JSON file structure or file path.")
+
+      def self.get_avd_schemes(params)
+
+        # Read JSON into string variable
+        avd_setup_json = read_avd_setup(params)
+        if avd_setup_json.nil?
+          throw_error("Unable to read AVD_setup.json. Check JSON file structure or file path.")
+        end
+
+        # Read JSON into Hash
+        avd_setup = JSON.parse(avd_setup_json)
+        avd_hash_list = avd_setup['avd_list']
+
+        # Create AVD_scheme objects and fill them with data
+        avd_scheme_list = []
+        for i in 0...avd_hash_list.length
+          avd_hash = avd_hash_list[i]
+
+          avd_scheme = AVD_scheme.new
+          avd_scheme.avd_name = avd_hash['avd_name']
+
+          avd_scheme.create_avd_package = avd_hash['create_avd_package']
+          avd_scheme.create_avd_device = avd_hash['create_avd_device']
+          avd_scheme.create_avd_tag = avd_hash['create_avd_tag']
+          avd_scheme.create_avd_abi = avd_hash['create_avd_abi']
+          avd_scheme.create_avd_hardware_config_filepath = avd_hash['create_avd_hardware_config_filepath']
+
+          avd_scheme.launch_avd_port = avd_hash['launch_avd_port']
+          avd_scheme.launch_avd_launch_binary_name = avd_hash['launch_avd_launch_binary_name']
+          avd_scheme.launch_avd_additional_options = avd_hash['launch_avd_additional_options']
+          avd_scheme.launch_avd_snapshot_filepath = avd_hash['launch_avd_snapshot_filepath']
+
+          errors = check_avd_fields(avd_scheme)
+          unless errors.empty?
+            error_log = "Error! Fields not found in JSON: \n"
+            errors.each { |error| error_log += error + "\n" }
+            throw_error(error_log)
           end
 
-          # Read JSON into Hash
-          avd_setup = JSON.parse(avd_setup_json)
-          avd_hash_list = avd_setup['avd_list']
+          avd_scheme_list << avd_scheme
+        end
 
-          # Create AVD_scheme objects and fill them with data
-          avd_scheme_list = []
-          for i in 0...avd_hash_list.length
-            avd_hash = avd_hash_list[i]
+        # Prepare list of open ports for AVD_schemes without ports set in JSON
+        avaliable_ports = get_unused_even_tcp_ports(5556, 5586, avd_scheme_list)
 
-            avd_scheme = AVD_scheme.new
-            avd_scheme.avd_name = avd_hash['avd_name']
-
-            avd_scheme.create_avd_package = avd_hash['create_avd_package']
-            avd_scheme.create_avd_device = avd_hash['create_avd_device']
-            avd_scheme.create_avd_tag = avd_hash['create_avd_tag']
-            avd_scheme.create_avd_abi = avd_hash['create_avd_abi']
-            avd_scheme.create_avd_hardware_config_filepath = avd_hash['create_avd_hardware_config_filepath']
-
-            avd_scheme.launch_avd_port = avd_hash['launch_avd_port']
-            avd_scheme.launch_avd_launch_binary_name = avd_hash['launch_avd_launch_binary_name']
-            avd_scheme.launch_avd_additional_options = avd_hash['launch_avd_additional_options']
-            avd_scheme.launch_avd_snapshot_filepath = avd_hash['launch_avd_snapshot_filepath']
-
-            errors = check_avd_fields(avd_scheme)
-            unless errors.empty?
-              error_log = "Error! Fields not found in JSON: \n"
-              errors.each { |error| error_log += error + "\n" }
-              throw_error(error_log)
-            end
-
-            avd_scheme_list << avd_scheme
+        # Fill empty AVD_schemes with open ports
+        for i in 0...avd_scheme_list.length
+          avd_scheme = avd_scheme_list[i]
+          if avd_scheme.launch_avd_port.eql? ""
+            avd_scheme.launch_avd_port = avaliable_ports[0]
+            avaliable_ports.delete(avaliable_ports[0])
           end
-          
-          # Prepare list of open ports for AVD_schemes without ports set in JSON
-          avaliable_ports = get_unused_even_tcp_ports(5556, 5586, avd_scheme_list)
+        end
 
-          # Fill empty AVD_schemes with open ports
-          for i in 0...avd_scheme_list.length
-            avd_scheme = avd_scheme_list[i]
-            if avd_scheme.launch_avd_port.eql? ""
-              avd_scheme.launch_avd_port = avaliable_ports[0]
-              avaliable_ports.delete(avaliable_ports[0])
-            end
+        return avd_scheme_list
+      end
+
+      def self.get_unused_even_tcp_ports(min_port, max_port, avd_scheme_list)
+        if min_port % 2 != 0
+          min_port += 1
+        end
+
+        if max_port % 2 != 0
+          max_port += 1
+        end
+
+        avaliable_ports = []
+        reserved_ports = []
+
+        # Gather ports requested in JSON config
+        for i in 0...avd_scheme_list.length
+          avd_scheme = avd_scheme_list[i]
+          unless avd_scheme.launch_avd_port.eql? ""
+            reserved_ports << avd_scheme.launch_avd_port
           end
+        end
 
-          return avd_scheme_list
-        end 
+        # Find next open port which wasn't reserved in JSON config
+        port = min_port
+        for i in 0...avd_scheme_list.length
 
-        def self.get_unused_even_tcp_ports(min_port, max_port, avd_scheme_list) 
-          if min_port % 2 != 0
-            min_port += 1
-          end
+          while port < max_port  do
+            if !system("lsof -i:#{port}", out: '/dev/null')
 
-          if max_port % 2 != 0
-            max_port += 1
-          end
-
-          avaliable_ports = []
-          reserved_ports = []
-
-          # Gather ports requested in JSON config
-          for i in 0...avd_scheme_list.length
-            avd_scheme = avd_scheme_list[i]
-            unless avd_scheme.launch_avd_port.eql? ""
-              reserved_ports << avd_scheme.launch_avd_port
-            end
-          end
-
-          # Find next open port which wasn't reserved in JSON config
-          port = min_port
-          for i in 0...avd_scheme_list.length
-            
-            while port < max_port  do
-              if !system("lsof -i:#{port}", out: '/dev/null')
-
-                is_port_reserved = false
-                for j in 0...reserved_ports.length 
-                  if reserved_ports[j].eql?(port.to_s)
-                    is_port_reserved = true
-                    break
-                  end
-                end
-
-                if is_port_reserved
-                  port = port + 2
+              is_port_reserved = false
+              for j in 0...reserved_ports.length
+                if reserved_ports[j].eql?(port.to_s)
+                  is_port_reserved = true
                   break
                 end
+              end
 
-                avaliable_ports << port
+              if is_port_reserved
                 port = port + 2
                 break
-              else 
-                port = port + 2
               end
+
+              avaliable_ports << port
+              port = port + 2
+              break
+            else
+              port = port + 2
             end
           end
-
-          return avaliable_ports
         end
 
-        def self.read_avd_setup(params)
-          if File.exists?(File.expand_path("#{params[:AVD_setup_path]}"))
-            file = File.open(File.expand_path("#{params[:AVD_setup_path]}"), "rb")
-            json = file.read
-            file.close
-            return json
-          else
-            return nil
-          end
-        end
+        return avaliable_ports
+      end
 
-        def self.check_avd_fields(avd_scheme)
-          errors = []
-            
-          if avd_scheme.avd_name.nil? 
-              errors.push("avd_name not found")
-          end
-          if avd_scheme.create_avd_package.nil? 
-              errors.push("create_avd_package not found")
-          end
-          if avd_scheme.create_avd_device.nil? 
-              errors.push("create_avd_device not found")
-          end
-          if avd_scheme.create_avd_tag.nil? 
-              errors.push("create_avd_tag not found")
-          end
-          if avd_scheme.create_avd_abi.nil? 
-              errors.push("create_avd_abi not found")
-          end
-          if avd_scheme.create_avd_hardware_config_filepath.nil? 
-              errors.push("create_avd_hardware_config_filepath not found")
-          end
-          if avd_scheme.launch_avd_snapshot_filepath.nil? 
-              errors.push("launch_avd_snapshot_filepath not found")
-          end
-          if avd_scheme.launch_avd_launch_binary_name.nil?
-            errors.push("launch_avd_launch_binary_name not found")
-          end
-          if avd_scheme.launch_avd_port.nil? 
-              errors.push("launch_avd_port not found")
-          end
-          if avd_scheme.launch_avd_additional_options.nil? 
-              errors.push("launch_avd_additional_options not found")
-          end
-          return errors
+      def self.read_avd_setup(params)
+        if File.exists?(File.expand_path("#{params[:AVD_setup_path]}"))
+          file = File.open(File.expand_path("#{params[:AVD_setup_path]}"), "rb")
+          json = file.read
+          file.close
+          return json
+        else
+          return nil
         end
+      end
 
-        def self.throw_error(message) 
-          UI.message("Error: ".red + message.red)
-          raise Exception, "Lane was stopped by plugin"
+      def self.check_avd_fields(avd_scheme)
+        errors = []
+
+        if avd_scheme.avd_name.nil?
+          errors.push("avd_name not found")
         end
+        if avd_scheme.create_avd_package.nil?
+          errors.push("create_avd_package not found")
+        end
+        if avd_scheme.create_avd_device.nil?
+          errors.push("create_avd_device not found")
+        end
+        if avd_scheme.create_avd_tag.nil?
+          errors.push("create_avd_tag not found")
+        end
+        if avd_scheme.create_avd_abi.nil?
+          errors.push("create_avd_abi not found")
+        end
+        if avd_scheme.create_avd_hardware_config_filepath.nil?
+          errors.push("create_avd_hardware_config_filepath not found")
+        end
+        if avd_scheme.launch_avd_snapshot_filepath.nil?
+          errors.push("launch_avd_snapshot_filepath not found")
+        end
+        if avd_scheme.launch_avd_launch_binary_name.nil?
+          errors.push("launch_avd_launch_binary_name not found")
+        end
+        if avd_scheme.launch_avd_port.nil?
+          errors.push("launch_avd_port not found")
+        end
+        if avd_scheme.launch_avd_additional_options.nil?
+          errors.push("launch_avd_additional_options not found")
+        end
+        return errors
+      end
+
+      def self.throw_error(message)
+        UI.message("Error: ".red + message.red)
+        raise Exception, "Lane was stopped by plugin"
+      end
     end
   end
 end


### PR DESCRIPTION
Updates rubocop rules to be compatible with 1.26.1.
Add 2 new cop rules: 
- Disable warning on CRLF endings
- Disable warning about using frozen string literals

Fix inconsistent indentation
Fix missing linebreak at the end of file